### PR TITLE
chore(): Upgrade node version, per github warning message 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: alert-triangle
   color: orange
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
 inputs:
   custom-domains:


### PR DESCRIPTION
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: gregsdennis/dependencies-action@v1.4.1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24